### PR TITLE
(fix) ts-add-js-extension breaks generic args in d.ts files

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -25,6 +25,7 @@ import type {
     InferParamsInFromBlock,
     InferBlock,
     InferHttpBlock,
+    InferResultOrResult,
 } from './types';
 import type BaseBlock from './block';
 import type { DescriptHttpBlockDescription, DescriptHttpBlockQuery, DescriptHttpBlockQueryValue } from './httpBlock';
@@ -160,7 +161,7 @@ const run = function<
     // block: FunctionBlock<Context, ParamsOut, BlockResult, ResultOut, BeforeResultOut, AfterResultOut, ErrorResultOut, Params>,
     { params, context, cancel }: {
         params?: Params; context?: Context; cancel?: Cancel;
-    } = {}) {
+    } = {}): Promise<InferResultOrResult<ResultOut>> {
     const runContext = new RunContext<BlockResult, IntermediateResult, ResultOut, Context, BeforeResultOut, AfterResultOut, ErrorResultOut>();
 
     if (!(params && typeof params === 'object')) {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "eslint": "npx eslint .",
         "test": "cd tests && ./gen-certs.sh && npx vitest",
         "ts-compile": "npx tsc --noEmit",
-        "prepack": "rm -rf build && npx tsc -p ./tsconfig-build.json && npx ts-add-js-extension --dir=build"
+        "prepack": "rm -rf build && npx tsc -p ./tsconfig-build.json && npx ts-add-js-extension --dir=build && npx tsc -p ./tsconfig-build.json -d"
     },
     "devDependencies": {
         "@eslint/js": "^9.21.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,7 @@
     "skipLibCheck": true, // https://www.typescriptlang.org/tsconfig#skipLibCheck
     "strict": false,
     "strictNullChecks": true,
-    "declaration":true,
+    "declaration":false,
 
     "baseUrl": ".",
     "outDir": "./build"


### PR DESCRIPTION
Add explicit result for de.run